### PR TITLE
Fix for 'all' query containing empty where condition

### DIFF
--- a/lib/resource-juggling.coffee
+++ b/lib/resource-juggling.coffee
@@ -40,11 +40,14 @@ exports.getResource = (options) ->
         callback err, [item]
       return
 
-    options.model.all
-      where: constraints
-    , (err, items) ->
+    notifyCallback = (err, items) ->
       items = [] unless items
       callback err, items
+
+    if(constraints.length)
+      options.model.all where: constraints, notifyCallback
+    else
+      options.model.all notifyCallback
 
   resource =
     id: options.urlName


### PR DESCRIPTION
Latest version of jugglingdb did not seem to like having an empty where condition provided when retrieving all items. Fix tested against `jugglingdb-redis`
